### PR TITLE
Add Logging to replace exception handeling and fix one poor overlap case

### DIFF
--- a/android/library/src/main/java/com/localytics/library/MediaTracker.java
+++ b/android/library/src/main/java/com/localytics/library/MediaTracker.java
@@ -1,5 +1,7 @@
 package com.localytics.library;
 
+import android.util.Log;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -69,20 +71,42 @@ public class MediaTracker {
 
     private void mergeOrCreateRange(int watchStart, int watchEnd) {
         if (watchStart < 0) {
-            throw new IllegalStateException("The video can't be tagged as stopped before it is tagged as started.");
+            Log.i("LocalyticsMediaTracker", "Media Tracker dropping stop datapoint.  A stop was " +
+                    "called before a start, this can occur when a start was never called or stop " +
+                    "was called multiple times in a row.");
+            return;
         }
-        if (watchEnd > videoDurationMS || watchStart > videoDurationMS) {
-            throw new IllegalArgumentException("The time input is greater than the duration of the media.");
+        if (watchEnd > videoDurationMS) {
+            Log.i("LocalyticsMediaTracker", "Media Tracker dropping stop datapoint.  A stop was " +
+                    "called with a time that is larger than the media duration.");
+            return;
         }
         boolean overlap = false;
         int i = 0;
         while (!overlap && i < rangesWatched.size()) {
-            overlap = rangesWatched.get(i++).mergeIfOverlapping(watchStart, watchEnd);
+            Range range = rangesWatched.get(i++);
+            overlap = range.mergeIfOverlapping(watchStart, watchEnd);
+            if (overlap) {
+                ensureNewRangehasNoOverlap(range);
+            }
         }
         if (!overlap) {
             rangesWatched.add(new Range(watchStart, watchEnd));
         }
         startedTime = -1;
+    }
+
+    private void ensureNewRangehasNoOverlap(Range input)
+    {
+        for (int i = 0; i < rangesWatched.size(); i++) {
+            Range range = rangesWatched.get(i);
+            if (range != input) { //avoid merging myself
+                if (input.mergeIfOverlapping(range.getStart(), range.getEnd())) {
+                    rangesWatched.remove(i);
+                    return;
+                }
+            }
+        }
     }
 
     private void tagEvent() {

--- a/android/library/src/main/java/com/localytics/library/MediaTracker.java
+++ b/android/library/src/main/java/com/localytics/library/MediaTracker.java
@@ -87,7 +87,7 @@ public class MediaTracker {
             Range range = rangesWatched.get(i++);
             overlap = range.mergeIfOverlapping(watchStart, watchEnd);
             if (overlap) {
-                ensureNewRangeHasNoOverlap(range);
+                removeOverlappingRanges(range);
             }
         }
         if (!overlap) {
@@ -96,7 +96,7 @@ public class MediaTracker {
         startedTime = -1;
     }
 
-    private void ensureNewRangeHasNoOverlap(Range input)
+    private void removeOverlappingRanges(Range input)
     {
         List<Range> toRemove = new ArrayList<>();
         for (int i = 0; i < rangesWatched.size(); i++) {

--- a/android/library/src/main/java/com/localytics/library/MediaTracker.java
+++ b/android/library/src/main/java/com/localytics/library/MediaTracker.java
@@ -87,7 +87,7 @@ public class MediaTracker {
             Range range = rangesWatched.get(i++);
             overlap = range.mergeIfOverlapping(watchStart, watchEnd);
             if (overlap) {
-                ensureNewRangehasNoOverlap(range);
+                ensureNewRangeHasNoOverlap(range);
             }
         }
         if (!overlap) {
@@ -96,7 +96,7 @@ public class MediaTracker {
         startedTime = -1;
     }
 
-    private void ensureNewRangehasNoOverlap(Range input)
+    private void ensureNewRangeHasNoOverlap(Range input)
     {
         List<Range> toRemove = new ArrayList<>();
         for (int i = 0; i < rangesWatched.size(); i++) {

--- a/android/library/src/main/java/com/localytics/library/MediaTracker.java
+++ b/android/library/src/main/java/com/localytics/library/MediaTracker.java
@@ -98,15 +98,16 @@ public class MediaTracker {
 
     private void ensureNewRangehasNoOverlap(Range input)
     {
+        List<Range> toRemove = new ArrayList<>();
         for (int i = 0; i < rangesWatched.size(); i++) {
             Range range = rangesWatched.get(i);
             if (range != input) { //avoid merging myself
                 if (input.mergeIfOverlapping(range.getStart(), range.getEnd())) {
-                    rangesWatched.remove(i);
-                    return;
+                    toRemove.add(range);
                 }
             }
         }
+        rangesWatched.removeAll(toRemove);
     }
 
     private void tagEvent() {

--- a/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
+++ b/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
@@ -5,8 +5,6 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Created by mriegelhaupt on 12/16/15.
@@ -84,35 +82,30 @@ public class MediaTrackerTest {
         mediaTracker.tagEventAtTime(1000000);
     }
 
-    @Test
-    public void testStopBeforeStartFailure() throws Exception {
-        MediaTracker mediaTracker = MediaTracker.create(1000000, new EventTagger() {
-            @Override
-            public void tagEvent(String eventName, Map<String, String> videoAttributes) { }
-        });
-        boolean exceptionCaught = false;
-        try {
-            mediaTracker.stopAtTime(500000);
-        } catch (Exception e) {
-            exceptionCaught = true;
-        }
-        assertTrue(exceptionCaught);
-    }
 
     @Test
-    public void testStopAfterMediaLengthFailure() throws Exception {
+    public void testDoubleOverlap() throws Exception {
         MediaTracker mediaTracker = MediaTracker.create(1000000, new EventTagger() {
             @Override
-            public void tagEvent(String eventName, Map<String, String> videoAttributes) { }
+            public void tagEvent(String eventName, Map<String, String> videoAttributes) {
+                assertEquals("1000", videoAttributes.get(MediaTracker.MEDIA_LENGTH_SECONDS));
+                assertEquals("450", videoAttributes.get(MediaTracker.TIME_PLAYED_SECONDS));
+                assertEquals("45", videoAttributes.get(MediaTracker.PERCENT_PLAYED));
+            }
         });
-        boolean exceptionCaught = false;
-        try {
-            mediaTracker.playAtTime(0);
-            mediaTracker.stopAtTime(5000000);
-        } catch (Exception e) {
-            exceptionCaught = true;
-        }
-        assertTrue(exceptionCaught);
+
+        //range 1
+        mediaTracker.playAtTime(50000);
+        mediaTracker.stopAtTime(150000);
+        //range 2
+        mediaTracker.playAtTime(300000);
+        mediaTracker.stopAtTime(500000);
+        //overlaps both ranges
+        mediaTracker.playAtTime(100000);
+        mediaTracker.stopAtTime(350000);
+
+        mediaTracker.tagEventAtTime(500000);
+
     }
 
 

--- a/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
+++ b/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
@@ -118,16 +118,16 @@ public class MediaTrackerTest {
             }
         });
 
-        //range 1
         mediaTracker.playAtTime(50000);
         mediaTracker.stopAtTime(150000);
-        //range 2
+
         mediaTracker.playAtTime(300000);
         mediaTracker.stopAtTime(500000);
-        //overlaps both ranges
+
         mediaTracker.playAtTime(600000);
         mediaTracker.stopAtTime(750000);
 
+        //overlaps all previous ranges
         mediaTracker.playAtTime(0);
         mediaTracker.stopAtTime(800000);
 

--- a/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
+++ b/android/library/src/test/java/com/localytics/library/MediaTrackerTest.java
@@ -105,7 +105,33 @@ public class MediaTrackerTest {
         mediaTracker.stopAtTime(350000);
 
         mediaTracker.tagEventAtTime(500000);
+    }
 
+    @Test
+    public void testCompleteOverlap() throws Exception {
+        MediaTracker mediaTracker = MediaTracker.create(1000000, new EventTagger() {
+            @Override
+            public void tagEvent(String eventName, Map<String, String> videoAttributes) {
+                assertEquals("1000", videoAttributes.get(MediaTracker.MEDIA_LENGTH_SECONDS));
+                assertEquals("800", videoAttributes.get(MediaTracker.TIME_PLAYED_SECONDS));
+                assertEquals("80", videoAttributes.get(MediaTracker.PERCENT_PLAYED));
+            }
+        });
+
+        //range 1
+        mediaTracker.playAtTime(50000);
+        mediaTracker.stopAtTime(150000);
+        //range 2
+        mediaTracker.playAtTime(300000);
+        mediaTracker.stopAtTime(500000);
+        //overlaps both ranges
+        mediaTracker.playAtTime(600000);
+        mediaTracker.stopAtTime(750000);
+
+        mediaTracker.playAtTime(0);
+        mediaTracker.stopAtTime(800000);
+
+        mediaTracker.tagEventAtTime(500000);
     }
 
 


### PR DESCRIPTION
Instead of throwing exceptions when a bad start or stop was called, we should only log messages.

I also found one bug in the range merging code.  Example:

Watched from 5s - 15s.
Watched from 30s - 50s.
Then finally watched from 10s - 35s.

Previously this would have reported a watch length of 50s instead of 45s because the merge step would have left two `Range`s, one from 5s-35s and one from 30s-50s.
